### PR TITLE
✨  feat: add optional subpath folder variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Using Airflow Git Sync is simple:
     | Variable | Description | Default Value |
     | --- | --- | --- |
     | `REPO_URL` | The URL of the Git repository to sync | `N/A` (required) |
+    | `SUBFOLDER_PATH` | The repository sub-folder to sync. Leaving empty copies the entire repo | `N/A` (optional) | 
     | `GIT_BRANCH` | The Git branch to sync | `main` |
     | `DIRECTORY_NAME` | The name of the directory to clone the repository into | `project` |
     | `DESTINATION_PATH` | The path to sync the repository to | `/app/sync` |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 PROJECT_DIRECTORY="/app/${DIRECTORY_NAME:-project}"
+SUBFOLDER=${SUBFOLDER_PATH:-""}  # Fetch the sub-folder path from an environment variable
 
 mkdir -p ~/.ssh
 
@@ -11,7 +12,7 @@ if [ ! -d "$PROJECT_DIRECTORY/.git" ]; then
   cd $PROJECT_DIRECTORY
   git remote add origin $REPO_URL
   git pull origin ${GIT_BRANCH:-main}
-  rsync -vazC $PROJECT_DIRECTORY/ ${DESTINATION_PATH:-/app/sync}
+  rsync -vazC $PROJECT_DIRECTORY/$SUBFOLDER ${DESTINATION_PATH:-/app/sync}
 fi
 
 if [[ "$PWD" != "$PROJECT_DIRECTORY" ]]
@@ -24,6 +25,9 @@ while true; do
   git -C $PROJECT_DIRECTORY pull origin ${GIT_BRANCH:-main}
   git clean -fd
   sleep ${INTERVAL:-10}
-  rsync -vazC $PROJECT_DIRECTORY/ ${DESTINATION_PATH:-/app/sync}
+  if [ -z "$SUBFOLDER" ]; then
+    rsync -vazC $PROJECT_DIRECTORY/ ${DESTINATION_PATH:-/app/sync}
+  else
+    rsync -vazC $PROJECT_DIRECTORY/$SUBFOLDER ${DESTINATION_PATH:-/app/sync}
+  fi
 done
-


### PR DESCRIPTION
This MR adds a new env variable for a "subfolder" location inside the repository.
In our case our DAGs folder is located in a specific sub-folder of the repo and we don't want the entire repo to be copied to airflow